### PR TITLE
feat: increase Streamlit file upload limits to 1GB

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -6,8 +6,8 @@ textColor = "#262730"
 font = "sans serif"
 
 [server]
-maxUploadSize = 200
-maxMessageSize = 200
+maxUploadSize = 1000
+maxMessageSize = 1000
 enableCORS = false
 
 [client]


### PR DESCRIPTION
## 概要
<!-- PRの背景・目的・概要 -->
音声録音を1hしただけでクラッシュするエラーの修正

## 関連タスク



## やったこと
<!-- このPRで何をしたのか？ -->
.streamlit/config.tomlを修正し、サーバーのmacUploadSizeとmaxMessageSizeを大きくした（200MB→1GB）

## やらないこと



## 影響範囲
<!-- 影響を及ぼす範囲や他の機能への影響 -->
音声録音・保存機能

## テスト
<!-- テスト方法や結果 -->
5分間の録音を試したが、エラーは起きず、録音と文字起こしに成功した。
1時間のテストはまだやっていない。

## 備考
